### PR TITLE
Added basic instructions panel, CSS fonts to info popup, and help tab with link to the modding discord.

### DIFF
--- a/BeatSaberModManager/BeatSaberModManager.csproj
+++ b/BeatSaberModManager/BeatSaberModManager.csproj
@@ -41,6 +41,9 @@
     <ApplicationIcon>saber.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.mshtml, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />

--- a/BeatSaberModManager/Forms/FormDetailViewer.Designer.cs
+++ b/BeatSaberModManager/Forms/FormDetailViewer.Designer.cs
@@ -43,7 +43,7 @@
             this.labelTitle.Font = new System.Drawing.Font("Segoe UI", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.labelTitle.Location = new System.Drawing.Point(11, 9);
             this.labelTitle.Name = "labelTitle";
-            this.labelTitle.Size = new System.Drawing.Size(249, 20);
+            this.labelTitle.Size = new System.Drawing.Size(250, 20);
             this.labelTitle.TabIndex = 0;
             this.labelTitle.Text = "Mod Name by Author Name Version";
             // 
@@ -100,6 +100,7 @@
             this.webBrowserDescription.Name = "webBrowserDescription";
             this.webBrowserDescription.Size = new System.Drawing.Size(605, 393);
             this.webBrowserDescription.TabIndex = 6;
+            this.webBrowserDescription.DocumentCompleted += new System.Windows.Forms.WebBrowserDocumentCompletedEventHandler(this.webBrowserDescription_DocumentCompleted);
             // 
             // FormDetailViewer
             // 

--- a/BeatSaberModManager/Forms/FormDetailViewer.cs
+++ b/BeatSaberModManager/Forms/FormDetailViewer.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Windows.Forms;
 using CommonMark;
 using BeatSaberModManager.DataModels;
+using mshtml;
 namespace BeatSaberModManager
 {
     public partial class FormDetailViewer : Form
@@ -19,7 +20,6 @@ namespace BeatSaberModManager
         {
             string description = CommonMarkConverter.Convert(_release.description);
             webBrowserDescription.DocumentText = description;
-           
         }
         private void buttonClose_Click(object sender, EventArgs e)
         {
@@ -32,6 +32,29 @@ namespace BeatSaberModManager
             {
                 Process.Start(_release.downloadLink);
             }
+        }
+
+        private void webBrowserDescription_DocumentCompleted(object sender, WebBrowserDocumentCompletedEventArgs e)
+        {
+            InitCSS();
+        }
+
+        // Add CSS styling to the webBrowser object
+        private void InitCSS()
+        {
+            IHTMLDocument2 document = (webBrowserDescription.Document.DomDocument) as IHTMLDocument2;
+
+            // The first parameter is the url, the second is the index of the added style sheet.
+            IHTMLStyleSheet styleSheet = document.createStyleSheet("", 0);
+
+            // Change the font for everything in the document. Font list taken from the Github readme page
+            int index = styleSheet.addRule("*", "font-family: -apple-system,BlinkMacSystemFont,\"Segoe UI\",Helvetica,Arial,sans-serif,\"Apple Color Emoji\",\"Segoe UI Emoji\",\"Segoe UI Symbol\";");
+
+            // Edit existing rules
+            // styleSheet.cssText = @"h1 { color: blue; }";
+
+            // Remove existing rules
+            // styleSheet.removeRule(index);
         }
     }
 }

--- a/BeatSaberModManager/Forms/FormMain.Designer.cs
+++ b/BeatSaberModManager/Forms/FormMain.Designer.cs
@@ -51,6 +51,9 @@
             this.labelModSaber2 = new System.Windows.Forms.Label();
             this.linkLabelModSaberLink = new System.Windows.Forms.LinkLabel();
             this.labelModSaber1 = new System.Windows.Forms.Label();
+            this.tabPageHelp = new System.Windows.Forms.TabPage();
+            this.linkLabelDiscord = new System.Windows.Forms.LinkLabel();
+            this.labelDiscordInfo = new System.Windows.Forms.Label();
             this.buttonViewInfo = new System.Windows.Forms.Button();
             this.panelInfo = new System.Windows.Forms.Panel();
             this.tableLayoutPanelInfo = new System.Windows.Forms.TableLayoutPanel();
@@ -58,10 +61,12 @@
             this.label2 = new System.Windows.Forms.Label();
             this.textBoxPluginsPath = new System.Windows.Forms.TextBox();
             this.helpInfoLabel3 = new System.Windows.Forms.Label();
+            this.label4 = new System.Windows.Forms.Label();
             this.tabControlMain.SuspendLayout();
             this.tabPageCore.SuspendLayout();
             this.contextMenuStripMain.SuspendLayout();
             this.tabPageCredits.SuspendLayout();
+            this.tabPageHelp.SuspendLayout();
             this.panelInfo.SuspendLayout();
             this.tableLayoutPanelInfo.SuspendLayout();
             this.SuspendLayout();
@@ -125,6 +130,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tabControlMain.Controls.Add(this.tabPageCore);
             this.tabControlMain.Controls.Add(this.tabPageCredits);
+            this.tabControlMain.Controls.Add(this.tabPageHelp);
             this.tabControlMain.Enabled = false;
             this.tabControlMain.Location = new System.Drawing.Point(10, 140);
             this.tabControlMain.Name = "tabControlMain";
@@ -287,6 +293,43 @@
             this.labelModSaber1.TabIndex = 0;
             this.labelModSaber1.Text = "Mod Hosting Platform Provided by ";
             // 
+            // tabPageHelp
+            // 
+            this.tabPageHelp.Controls.Add(this.label4);
+            this.tabPageHelp.Controls.Add(this.linkLabelDiscord);
+            this.tabPageHelp.Controls.Add(this.labelDiscordInfo);
+            this.tabPageHelp.Location = new System.Drawing.Point(4, 22);
+            this.tabPageHelp.Name = "tabPageHelp";
+            this.tabPageHelp.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPageHelp.Size = new System.Drawing.Size(536, 229);
+            this.tabPageHelp.TabIndex = 2;
+            this.tabPageHelp.Text = "Help";
+            this.tabPageHelp.UseVisualStyleBackColor = true;
+            // 
+            // linkLabelDiscord
+            // 
+            this.linkLabelDiscord.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.linkLabelDiscord.AutoSize = true;
+            this.linkLabelDiscord.Location = new System.Drawing.Point(189, 137);
+            this.linkLabelDiscord.Name = "linkLabelDiscord";
+            this.linkLabelDiscord.Size = new System.Drawing.Size(145, 13);
+            this.linkLabelDiscord.TabIndex = 1;
+            this.linkLabelDiscord.TabStop = true;
+            this.linkLabelDiscord.Text = "discord.gg/beatsabermods";
+            this.linkLabelDiscord.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.linkLabelDiscord.Click += new System.EventHandler(this.linkLabelDiscord_Click);
+            // 
+            // labelDiscordInfo
+            // 
+            this.labelDiscordInfo.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.labelDiscordInfo.AutoSize = true;
+            this.labelDiscordInfo.Location = new System.Drawing.Point(117, 114);
+            this.labelDiscordInfo.Name = "labelDiscordInfo";
+            this.labelDiscordInfo.Size = new System.Drawing.Size(303, 13);
+            this.labelDiscordInfo.TabIndex = 0;
+            this.labelDiscordInfo.Text = "Join us on the Beat Saber Modding Group Discord server!";
+            this.labelDiscordInfo.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
             // buttonViewInfo
             // 
             this.buttonViewInfo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
@@ -348,10 +391,9 @@
             this.label2.AutoSize = true;
             this.label2.Location = new System.Drawing.Point(3, 56);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(530, 13);
+            this.label2.Size = new System.Drawing.Size(378, 13);
             this.label2.TabIndex = 4;
-            this.label2.Text = "Select a mod then click the \"View Selected Mod Info\" button to see more informati" +
-    "on about that mod.";
+            this.label2.Text = "Right click on a mod in the list below to view more info about that mod.";
             // 
             // textBoxPluginsPath
             // 
@@ -378,6 +420,17 @@
             this.helpInfoLabel3.TabIndex = 3;
             this.helpInfoLabel3.Text = "You can uninstall mods by removing the .dll from that folder.";
             // 
+            // label4
+            // 
+            this.label4.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(212, 91);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(94, 13);
+            this.label4.TabIndex = 2;
+            this.label4.Text = "Need more help?";
+            this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
             // FormMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -402,6 +455,8 @@
             this.contextMenuStripMain.ResumeLayout(false);
             this.tabPageCredits.ResumeLayout(false);
             this.tabPageCredits.PerformLayout();
+            this.tabPageHelp.ResumeLayout(false);
+            this.tabPageHelp.PerformLayout();
             this.panelInfo.ResumeLayout(false);
             this.tableLayoutPanelInfo.ResumeLayout(false);
             this.tableLayoutPanelInfo.PerformLayout();
@@ -440,6 +495,10 @@
         private System.Windows.Forms.Label helpInfoLabel3;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.TextBox textBoxPluginsPath;
+        private System.Windows.Forms.TabPage tabPageHelp;
+        private System.Windows.Forms.Label labelDiscordInfo;
+        private System.Windows.Forms.LinkLabel linkLabelDiscord;
+        private System.Windows.Forms.Label label4;
     }
 }
 

--- a/BeatSaberModManager/Forms/FormMain.Designer.cs
+++ b/BeatSaberModManager/Forms/FormMain.Designer.cs
@@ -44,6 +44,7 @@
             this.contextMenuStripMain = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.viewInfoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tabPageCredits = new System.Windows.Forms.TabPage();
+            this.linkLabelContributors = new System.Windows.Forms.LinkLabel();
             this.linkLabellolPants = new System.Windows.Forms.LinkLabel();
             this.linkLabelUmbranox = new System.Windows.Forms.LinkLabel();
             this.label3 = new System.Windows.Forms.Label();
@@ -51,11 +52,18 @@
             this.linkLabelModSaberLink = new System.Windows.Forms.LinkLabel();
             this.labelModSaber1 = new System.Windows.Forms.Label();
             this.buttonViewInfo = new System.Windows.Forms.Button();
-            this.linkLabelContributors = new System.Windows.Forms.LinkLabel();
+            this.panelInfo = new System.Windows.Forms.Panel();
+            this.tableLayoutPanelInfo = new System.Windows.Forms.TableLayoutPanel();
+            this.helpInfoLabel1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.textBoxPluginsPath = new System.Windows.Forms.TextBox();
+            this.helpInfoLabel3 = new System.Windows.Forms.Label();
             this.tabControlMain.SuspendLayout();
             this.tabPageCore.SuspendLayout();
             this.contextMenuStripMain.SuspendLayout();
             this.tabPageCredits.SuspendLayout();
+            this.panelInfo.SuspendLayout();
+            this.tableLayoutPanelInfo.SuspendLayout();
             this.SuspendLayout();
             // 
             // textBoxDirectory
@@ -67,6 +75,7 @@
             this.textBoxDirectory.Name = "textBoxDirectory";
             this.textBoxDirectory.Size = new System.Drawing.Size(508, 22);
             this.textBoxDirectory.TabIndex = 0;
+            this.textBoxDirectory.TextChanged += new System.EventHandler(this.textBoxDirectory_TextChanged);
             // 
             // buttonFolderBrowser
             // 
@@ -91,7 +100,7 @@
             // buttonInstall
             // 
             this.buttonInstall.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonInstall.Location = new System.Drawing.Point(440, 341);
+            this.buttonInstall.Location = new System.Drawing.Point(440, 401);
             this.buttonInstall.Name = "buttonInstall";
             this.buttonInstall.Size = new System.Drawing.Size(112, 23);
             this.buttonInstall.TabIndex = 4;
@@ -103,7 +112,7 @@
             // 
             this.labelStatus.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.labelStatus.Location = new System.Drawing.Point(7, 346);
+            this.labelStatus.Location = new System.Drawing.Point(7, 406);
             this.labelStatus.Name = "labelStatus";
             this.labelStatus.Size = new System.Drawing.Size(263, 145);
             this.labelStatus.TabIndex = 5;
@@ -117,10 +126,10 @@
             this.tabControlMain.Controls.Add(this.tabPageCore);
             this.tabControlMain.Controls.Add(this.tabPageCredits);
             this.tabControlMain.Enabled = false;
-            this.tabControlMain.Location = new System.Drawing.Point(10, 53);
+            this.tabControlMain.Location = new System.Drawing.Point(10, 140);
             this.tabControlMain.Name = "tabControlMain";
             this.tabControlMain.SelectedIndex = 0;
-            this.tabControlMain.Size = new System.Drawing.Size(544, 282);
+            this.tabControlMain.Size = new System.Drawing.Size(544, 255);
             this.tabControlMain.TabIndex = 8;
             // 
             // tabPageCore
@@ -129,7 +138,7 @@
             this.tabPageCore.Location = new System.Drawing.Point(4, 22);
             this.tabPageCore.Name = "tabPageCore";
             this.tabPageCore.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPageCore.Size = new System.Drawing.Size(536, 256);
+            this.tabPageCore.Size = new System.Drawing.Size(536, 229);
             this.tabPageCore.TabIndex = 0;
             this.tabPageCore.Text = "Plugins";
             this.tabPageCore.UseVisualStyleBackColor = true;
@@ -148,7 +157,7 @@
             this.listViewMods.FullRowSelect = true;
             this.listViewMods.Location = new System.Drawing.Point(6, 6);
             this.listViewMods.Name = "listViewMods";
-            this.listViewMods.Size = new System.Drawing.Size(524, 244);
+            this.listViewMods.Size = new System.Drawing.Size(524, 217);
             this.listViewMods.TabIndex = 0;
             this.listViewMods.UseCompatibleStateImageBehavior = false;
             this.listViewMods.View = System.Windows.Forms.View.Details;
@@ -195,16 +204,28 @@
             this.tabPageCredits.Controls.Add(this.labelModSaber1);
             this.tabPageCredits.Location = new System.Drawing.Point(4, 22);
             this.tabPageCredits.Name = "tabPageCredits";
-            this.tabPageCredits.Size = new System.Drawing.Size(536, 256);
+            this.tabPageCredits.Size = new System.Drawing.Size(536, 229);
             this.tabPageCredits.TabIndex = 1;
             this.tabPageCredits.Text = "Mod Manager Credits";
             this.tabPageCredits.UseVisualStyleBackColor = true;
+            // 
+            // linkLabelContributors
+            // 
+            this.linkLabelContributors.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.linkLabelContributors.AutoSize = true;
+            this.linkLabelContributors.Location = new System.Drawing.Point(232, 137);
+            this.linkLabelContributors.Name = "linkLabelContributors";
+            this.linkLabelContributors.Size = new System.Drawing.Size(73, 13);
+            this.linkLabelContributors.TabIndex = 7;
+            this.linkLabelContributors.TabStop = true;
+            this.linkLabelContributors.Text = "Contributors";
+            this.linkLabelContributors.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelContributors_LinkClicked);
             // 
             // linkLabellolPants
             // 
             this.linkLabellolPants.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.linkLabellolPants.AutoSize = true;
-            this.linkLabellolPants.Location = new System.Drawing.Point(383, 99);
+            this.linkLabellolPants.Location = new System.Drawing.Point(383, 91);
             this.linkLabellolPants.Name = "linkLabellolPants";
             this.linkLabellolPants.Size = new System.Drawing.Size(48, 13);
             this.linkLabellolPants.TabIndex = 5;
@@ -216,7 +237,7 @@
             // 
             this.linkLabelUmbranox.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.linkLabelUmbranox.AutoSize = true;
-            this.linkLabelUmbranox.Location = new System.Drawing.Point(302, 122);
+            this.linkLabelUmbranox.Location = new System.Drawing.Point(302, 114);
             this.linkLabelUmbranox.Name = "linkLabelUmbranox";
             this.linkLabelUmbranox.Size = new System.Drawing.Size(60, 13);
             this.linkLabelUmbranox.TabIndex = 4;
@@ -228,7 +249,7 @@
             // 
             this.label3.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(174, 122);
+            this.label3.Location = new System.Drawing.Point(174, 114);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(134, 13);
             this.label3.TabIndex = 3;
@@ -238,7 +259,7 @@
             // 
             this.labelModSaber2.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.labelModSaber2.AutoSize = true;
-            this.labelModSaber2.Location = new System.Drawing.Point(326, 99);
+            this.labelModSaber2.Location = new System.Drawing.Point(326, 91);
             this.labelModSaber2.Name = "labelModSaber2";
             this.labelModSaber2.Size = new System.Drawing.Size(60, 13);
             this.labelModSaber2.TabIndex = 2;
@@ -248,7 +269,7 @@
             // 
             this.linkLabelModSaberLink.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.linkLabelModSaberLink.AutoSize = true;
-            this.linkLabelModSaberLink.Location = new System.Drawing.Point(256, 99);
+            this.linkLabelModSaberLink.Location = new System.Drawing.Point(256, 91);
             this.linkLabelModSaberLink.Name = "linkLabelModSaberLink";
             this.linkLabelModSaberLink.Size = new System.Drawing.Size(73, 13);
             this.linkLabelModSaberLink.TabIndex = 1;
@@ -260,7 +281,7 @@
             // 
             this.labelModSaber1.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.labelModSaber1.AutoSize = true;
-            this.labelModSaber1.Location = new System.Drawing.Point(75, 99);
+            this.labelModSaber1.Location = new System.Drawing.Point(75, 91);
             this.labelModSaber1.Name = "labelModSaber1";
             this.labelModSaber1.Size = new System.Drawing.Size(187, 13);
             this.labelModSaber1.TabIndex = 0;
@@ -270,7 +291,7 @@
             // 
             this.buttonViewInfo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonViewInfo.Enabled = false;
-            this.buttonViewInfo.Location = new System.Drawing.Point(276, 341);
+            this.buttonViewInfo.Location = new System.Drawing.Point(276, 401);
             this.buttonViewInfo.Name = "buttonViewInfo";
             this.buttonViewInfo.Size = new System.Drawing.Size(158, 23);
             this.buttonViewInfo.TabIndex = 9;
@@ -278,23 +299,91 @@
             this.buttonViewInfo.UseVisualStyleBackColor = true;
             this.buttonViewInfo.Click += new System.EventHandler(this.buttonViewInfo_Click);
             // 
-            // linkLabelContributors
+            // panelInfo
             // 
-            this.linkLabelContributors.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.linkLabelContributors.AutoSize = true;
-            this.linkLabelContributors.Location = new System.Drawing.Point(232, 145);
-            this.linkLabelContributors.Name = "linkLabelContributors";
-            this.linkLabelContributors.Size = new System.Drawing.Size(73, 13);
-            this.linkLabelContributors.TabIndex = 7;
-            this.linkLabelContributors.TabStop = true;
-            this.linkLabelContributors.Text = "Contributors";
-            this.linkLabelContributors.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelContributors_LinkClicked);
+            this.panelInfo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.panelInfo.BackColor = System.Drawing.SystemColors.Info;
+            this.panelInfo.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.panelInfo.Controls.Add(this.tableLayoutPanelInfo);
+            this.panelInfo.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.panelInfo.Location = new System.Drawing.Point(10, 54);
+            this.panelInfo.Name = "panelInfo";
+            this.panelInfo.Size = new System.Drawing.Size(542, 80);
+            this.panelInfo.TabIndex = 10;
+            // 
+            // tableLayoutPanelInfo
+            // 
+            this.tableLayoutPanelInfo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanelInfo.BackColor = System.Drawing.SystemColors.Info;
+            this.tableLayoutPanelInfo.ColumnCount = 1;
+            this.tableLayoutPanelInfo.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanelInfo.Controls.Add(this.helpInfoLabel1, 0, 0);
+            this.tableLayoutPanelInfo.Controls.Add(this.label2, 0, 4);
+            this.tableLayoutPanelInfo.Controls.Add(this.textBoxPluginsPath, 0, 1);
+            this.tableLayoutPanelInfo.Controls.Add(this.helpInfoLabel3, 0, 3);
+            this.tableLayoutPanelInfo.Location = new System.Drawing.Point(-1, 3);
+            this.tableLayoutPanelInfo.Name = "tableLayoutPanelInfo";
+            this.tableLayoutPanelInfo.RowCount = 5;
+            this.tableLayoutPanelInfo.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 25F));
+            this.tableLayoutPanelInfo.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 25F));
+            this.tableLayoutPanelInfo.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 25F));
+            this.tableLayoutPanelInfo.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 25F));
+            this.tableLayoutPanelInfo.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanelInfo.Size = new System.Drawing.Size(542, 79);
+            this.tableLayoutPanelInfo.TabIndex = 13;
+            // 
+            // helpInfoLabel1
+            // 
+            this.helpInfoLabel1.AutoSize = true;
+            this.helpInfoLabel1.Location = new System.Drawing.Point(3, 0);
+            this.helpInfoLabel1.Name = "helpInfoLabel1";
+            this.helpInfoLabel1.Size = new System.Drawing.Size(269, 13);
+            this.helpInfoLabel1.TabIndex = 0;
+            this.helpInfoLabel1.Text = "Most mods will install a .dll into the Plugins folder:";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(3, 56);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(530, 13);
+            this.label2.TabIndex = 4;
+            this.label2.Text = "Select a mod then click the \"View Selected Mod Info\" button to see more informati" +
+    "on about that mod.";
+            // 
+            // textBoxPluginsPath
+            // 
+            this.textBoxPluginsPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.textBoxPluginsPath.BackColor = System.Drawing.SystemColors.Info;
+            this.textBoxPluginsPath.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.textBoxPluginsPath.Location = new System.Drawing.Point(6, 17);
+            this.textBoxPluginsPath.Margin = new System.Windows.Forms.Padding(6, 3, 3, 3);
+            this.textBoxPluginsPath.Name = "textBoxPluginsPath";
+            this.textBoxPluginsPath.ReadOnly = true;
+            this.textBoxPluginsPath.ScrollBars = System.Windows.Forms.ScrollBars.Horizontal;
+            this.textBoxPluginsPath.Size = new System.Drawing.Size(533, 15);
+            this.textBoxPluginsPath.TabIndex = 5;
+            this.textBoxPluginsPath.Click += new System.EventHandler(this.textBoxPluginsPath_Click);
+            this.textBoxPluginsPath.Leave += new System.EventHandler(this.textBoxPluginsPath_Leave);
+            // 
+            // helpInfoLabel3
+            // 
+            this.helpInfoLabel3.AutoSize = true;
+            this.helpInfoLabel3.Location = new System.Drawing.Point(3, 42);
+            this.helpInfoLabel3.Name = "helpInfoLabel3";
+            this.helpInfoLabel3.Size = new System.Drawing.Size(319, 13);
+            this.helpInfoLabel3.TabIndex = 3;
+            this.helpInfoLabel3.Text = "You can uninstall mods by removing the .dll from that folder.";
             // 
             // FormMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(566, 376);
+            this.ClientSize = new System.Drawing.Size(566, 436);
+            this.Controls.Add(this.panelInfo);
             this.Controls.Add(this.buttonViewInfo);
             this.Controls.Add(this.tabControlMain);
             this.Controls.Add(this.labelStatus);
@@ -313,6 +402,9 @@
             this.contextMenuStripMain.ResumeLayout(false);
             this.tabPageCredits.ResumeLayout(false);
             this.tabPageCredits.PerformLayout();
+            this.panelInfo.ResumeLayout(false);
+            this.tableLayoutPanelInfo.ResumeLayout(false);
+            this.tableLayoutPanelInfo.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -342,6 +434,12 @@
         private System.Windows.Forms.Label labelModSaber1;
         private System.Windows.Forms.LinkLabel linkLabellolPants;
         private System.Windows.Forms.LinkLabel linkLabelContributors;
+        private System.Windows.Forms.Panel panelInfo;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanelInfo;
+        private System.Windows.Forms.Label helpInfoLabel1;
+        private System.Windows.Forms.Label helpInfoLabel3;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.TextBox textBoxPluginsPath;
     }
 }
 

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -189,5 +189,10 @@ namespace BeatSaberModManager
             textBoxPluginsPath.DeselectAll();
         }
         #endregion
+
+        private void linkLabelDiscord_Click(object sender, EventArgs e)
+        {
+            Process.Start("https://discord.gg/beatsabermods");
+        }
     }
 }

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -188,11 +188,11 @@ namespace BeatSaberModManager
         {
             textBoxPluginsPath.DeselectAll();
         }
-        #endregion
 
         private void linkLabelDiscord_Click(object sender, EventArgs e)
         {
             Process.Start("https://discord.gg/beatsabermods");
         }
+        #endregion
     }
 }

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -166,7 +166,28 @@ namespace BeatSaberModManager
         {
             Process.Start("https://github.com/Umbranoxio/BeatSaberModInstaller/graphs/contributors");
         }
-        #endregion
 
+        private void textBoxDirectory_TextChanged(object sender, EventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(textBoxDirectory.Text))
+            {
+                textBoxPluginsPath.Text = "${Install Directory}\\Plugins";
+            }
+            else
+            {
+                textBoxPluginsPath.Text = textBoxDirectory.Text + "\\Plugins";
+            }
+        }
+
+        private void textBoxPluginsPath_Click(object sender, System.EventArgs e)
+        {
+            textBoxPluginsPath.SelectAll();
+        }
+
+        private void textBoxPluginsPath_Leave(object sender, System.EventArgs e)
+        {
+            textBoxPluginsPath.DeselectAll();
+        }
+        #endregion
     }
 }

--- a/BeatSaberModManager/Forms/FormMain.resx
+++ b/BeatSaberModManager/Forms/FormMain.resx
@@ -120,6 +120,9 @@
   <metadata name="contextMenuStripMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="textBoxPluginsPath.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>


### PR DESCRIPTION
+ Added new info panel at the top of the installer to provide basic instructions to the user.
+ Added CSS fonts to stylize the info windows that popup when displaying information about a mod.
+ Added a new help tab that links to the Beat Saber Modding Group Discord server.

Screenshots taken on Win 7

Note: The path to the Plugins folder conforms to the path selected by the installer.
![image](https://user-images.githubusercontent.com/27714637/44822912-53027b00-abb2-11e8-893e-0548d3ff187e.png)

CSS fonts replace the default Times New Roman.
![image](https://user-images.githubusercontent.com/27714637/44823003-bab8c600-abb2-11e8-82a6-4d3e0147466b.png)

Help tab with link to the Modding Group discord.
![image](https://user-images.githubusercontent.com/27714637/44822930-5d247980-abb2-11e8-9848-cdd980aded84.png)
