### PR TITLE
More informative connection error messages

### DIFF
--- a/BeatSaberModManager/Core/Helper.cs
+++ b/BeatSaberModManager/Core/Helper.cs
@@ -11,28 +11,19 @@ namespace BeatSaberModManager.Core
         private static CookieContainer PermCookie;
         public static string Get(string URL)
         {
-            try
-            {
-                if (PermCookie == null) { PermCookie = new CookieContainer(); }
-                HttpWebRequest RQuest = (HttpWebRequest)HttpWebRequest.Create(URL);
-                RQuest.Method = "GET";
-                RQuest.KeepAlive = true;
-                RQuest.CookieContainer = PermCookie;
-                RQuest.ContentType = "application/x-www-form-urlencoded";
-                RQuest.Referer = "";
-                RQuest.UserAgent = "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.2 (KHTML, like Gecko) Chrome/15.0.874.121 Safari/535.2";
-                HttpWebResponse Response = (HttpWebResponse)RQuest.GetResponse();
-                StreamReader Sr = new StreamReader(Response.GetResponseStream());
-                string Code = Sr.ReadToEnd();
-                Sr.Close();
-                return Code;
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show("Failed to get version info! Please check your internet connection!", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                Environment.Exit(0);
-                return null;
-            }
+            if (PermCookie == null) { PermCookie = new CookieContainer(); }
+            HttpWebRequest RQuest = (HttpWebRequest)HttpWebRequest.Create(URL);
+            RQuest.Method = "GET";
+            RQuest.KeepAlive = true;
+            RQuest.CookieContainer = PermCookie;
+            RQuest.ContentType = "application/x-www-form-urlencoded";
+            RQuest.Referer = "";
+            RQuest.UserAgent = "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.2 (KHTML, like Gecko) Chrome/15.0.874.121 Safari/535.2";
+            HttpWebResponse Response = (HttpWebResponse)RQuest.GetResponse();
+            StreamReader Sr = new StreamReader(Response.GetResponseStream());
+            string Code = Sr.ReadToEnd();
+            Sr.Close();
+            return Code;
         }
         public static void UnzipFile(byte[] data, string directory)
         {

--- a/BeatSaberModManager/Core/RemoteLogic.cs
+++ b/BeatSaberModManager/Core/RemoteLogic.cs
@@ -89,18 +89,12 @@ namespace BeatSaberModManager.Core
             }
         }
 
-        public void CheckVersion()
+        public bool CheckIfLatestInstallerVersion()
         {
             //TODO: Don't be lazy and actually make an auto updater
-            Int16 version = Convert.ToInt16(Helper.Get(
-                "https://raw.githubusercontent.com/Umbranoxio/BeatSaberModInstaller/master/update.txt"));
-            if (version > CurrentVersion)
-            {
-                MessageBox.Show("Your version of the mod installer is outdated! Please download the new one!", "Update available!", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-                Process.Start("https://github.com/Umbranoxio/BeatSaberModInstaller/releases");
-                Process.GetCurrentProcess().Kill();
-                Environment.Exit(0);
-            }
+            var latestVersionStr = Helper.Get("https://raw.githubusercontent.com/Umbranoxio/BeatSaberModInstaller/master/update.txt");
+            var latestVersion = Convert.ToInt16(latestVersionStr);
+            return CurrentVersion >= latestVersion;
         }
     }
 }


### PR DESCRIPTION
I've seen a lot of people being confused by the generic connection error message, when it is really just ModSaber being temporarily unavailable. This should help with that.

Connection exceptions are now caught in FormMain instead of directly in Helper.Get() to allow for contextual error messages.

![beatsabermodmanager_2018-09-21_22-20-01](https://user-images.githubusercontent.com/1781420/45910331-837fb280-be08-11e8-8a02-55b747ea04e5.png)
