### PR TITLE
Show installed plugin version

### DIFF
--- a/BeatSaberModManager/BeatSaberModManager.csproj
+++ b/BeatSaberModManager/BeatSaberModManager.csproj
@@ -60,6 +60,7 @@
   <ItemGroup>
     <Compile Include="Core\GroupSorter.cs" />
     <Compile Include="Core\Helper.cs" />
+    <Compile Include="Core\InstalledPluginsLogic.cs" />
     <Compile Include="Core\InstallerLogic.cs" />
     <Compile Include="Core\PathLogic.cs" />
     <Compile Include="Core\RemoteLogic.cs" />
@@ -67,6 +68,7 @@
     <Compile Include="DataModels\ModLink.cs" />
     <Compile Include="DataModels\Platform.cs" />
     <Compile Include="DataModels\ReleaseInfo.cs" />
+    <Compile Include="Dependencies\AssemblyLocator.cs" />
     <Compile Include="Dependencies\CommonMark\CommonMarkAdditionalFeatures.cs" />
     <Compile Include="Dependencies\CommonMark\CommonMarkConverter.cs" />
     <Compile Include="Dependencies\CommonMark\CommonMarkException.cs" />

--- a/BeatSaberModManager/Core/InstalledPluginsLogic.cs
+++ b/BeatSaberModManager/Core/InstalledPluginsLogic.cs
@@ -53,13 +53,14 @@ namespace BeatSaberModManager.Core
             AssemblyLocator.Init();
             Assembly illusionPlugin = LoadBeatSaberAssemblies(installPath);
 
-            if (illusionPlugin == null)
-                return Plugins;
+            if (illusionPlugin == null) return Plugins;
 
             // IPlugin interface is implemented by Mods
             Type iPlugin = illusionPlugin.GetType("IllusionPlugin.IPlugin");
 
             string pluginPath = Path.Combine(installPath, PluginDir);
+            if (!Directory.Exists(pluginPath)) return Plugins;
+
             var pluginFiles = Directory.GetFiles(pluginPath, "*.dll");
             foreach (var pluginFile in pluginFiles)
             {

--- a/BeatSaberModManager/Core/InstalledPluginsLogic.cs
+++ b/BeatSaberModManager/Core/InstalledPluginsLogic.cs
@@ -50,6 +50,7 @@ namespace BeatSaberModManager.Core
         /// <returns>Installed Plugins as (name, version)Dictionary</returns>
         public Dictionary<string, string> LoadInstalledPlugins(string installPath)
         {
+            if (installPath == null || installPath == "") return null;
             Plugins = new Dictionary<string, string>();
             AssemblyLocator.Init();
             Assembly illusionPlugin = LoadBeatSaberAssemblies(installPath);

--- a/BeatSaberModManager/Core/InstalledPluginsLogic.cs
+++ b/BeatSaberModManager/Core/InstalledPluginsLogic.cs
@@ -1,0 +1,123 @@
+﻿using BeatSaberModManager.Dependencies;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BeatSaberModManager.Core
+{
+    public class InstalledPluginsLogic
+    {
+        private static readonly List<string> BeatSaberDirs = new List<string>() { @"Beat Saber_Data\Managed", @"IPA\Data\Managed" };
+        private const string PluginDir = "Plugins";
+
+        public Dictionary<string, string> Plugins { get; set; }
+
+        private Assembly LoadBeatSaberAssemblies(string installPath)
+        {
+            Assembly illusionPlugin = null;
+
+            foreach (var dir in BeatSaberDirs)
+            {
+                var path = Path.Combine(installPath, dir);
+                if (!Directory.Exists(path))
+                    continue;
+                var dlls = Directory.GetFiles(path, "*.dll");
+                foreach (var dll in dlls)
+                {
+                    try
+                    {
+                        var assembly = Assembly.LoadFile(dll);
+                        if (assembly.GetName().Name == "IllusionPlugin")
+                        {
+                            illusionPlugin = assembly;
+                        }
+                    }
+                    catch { } // Skip unloadable DLLs
+                }
+            }
+            return illusionPlugin;
+        }
+
+        /// <summary>
+        /// Loads the currently installed Plugins 
+        /// </summary>
+        /// <param name="installPath">BeatSaber installation path</param>
+        /// <returns>Installed Plugins as (name, version)Dictionary</returns>
+        public Dictionary<string, string> LoadInstalledPlugins(string installPath)
+        {
+            Plugins = new Dictionary<string, string>();
+            AssemblyLocator.Init();
+            Assembly illusionPlugin = LoadBeatSaberAssemblies(installPath);
+
+            if (illusionPlugin == null)
+                return Plugins;
+
+            // IPlugin interface is implemented by Mods
+            Type iPlugin = illusionPlugin.GetType("IllusionPlugin.IPlugin");
+
+            string pluginPath = Path.Combine(installPath, PluginDir);
+            var pluginFiles = Directory.GetFiles(pluginPath, "*.dll");
+            foreach (var pluginFile in pluginFiles)
+            {
+                try
+                {
+                    var assembly = Assembly.LoadFile(pluginFile);
+                    foreach (var type in assembly.GetExportedTypes())
+                    {
+                        if (!type.GetInterfaces().Contains(iPlugin))
+                            continue;
+                        object pluginInstance = Activator.CreateInstance(type);
+                        
+                        string name = null;
+                        string version = null;
+
+                        // We can not access these properties directly because they could be private
+                        foreach (var property in type.GetRuntimeProperties())
+                        {
+                            if (property.Name == "Name" || property.Name == "IPlugin.Name" || property.Name == "IllusionPlugin.IPlugin.Name")
+                                name = (string)property.GetValue(pluginInstance);
+                            else if (property.Name == "Version" || property.Name == "IPlugin.Version" || property.Name == "IllusionPlugin.IPlugin.Version")
+                                version = (string)property.GetValue(pluginInstance);
+                        }
+                        AddPlugin(name, version);
+                    }
+                }
+                catch { } // Skip unloadable DLLs
+
+            }
+            return Plugins;
+        }
+
+        /// <summary>
+        /// This method tries to correct slight differences between plugin names.
+        /// The Plugin name on modsaber isnt always identical to the name inside the DLL.
+        /// </summary>
+        /// <param name="name">plugin name</param>
+        /// <returns>corrected name</returns>
+        private string GeneralizeName(string name)
+        {
+            name = name.Replace(" ", "");
+            name = name.Replace("Plugin", "");
+            return name;
+        }
+
+        private void AddPlugin(string name, string version)
+        {
+            Plugins.Add(GeneralizeName(name), version);
+        }
+
+        public string GetInstalledVersion(string name)
+        {
+            name = GeneralizeName(name);
+            if (Plugins == null)
+                return null;
+            if (!Plugins.ContainsKey(name))
+                return null;
+            return Plugins[name];
+        }
+    }
+}

--- a/BeatSaberModManager/Core/InstalledPluginsLogic.cs
+++ b/BeatSaberModManager/Core/InstalledPluginsLogic.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using SemVer;
 
 namespace BeatSaberModManager.Core
 {
@@ -118,7 +119,16 @@ namespace BeatSaberModManager.Core
                 return null;
             if (!Plugins.ContainsKey(name))
                 return null;
-            return Plugins[name];
+            try
+            {
+                var version = new SemVer.Version(Plugins[name], true);
+                var baseVersion = version.BaseVersion();
+                return baseVersion.ToString();
+            }
+            catch
+            {
+                return Plugins[name];
+            }
         }
     }
 }

--- a/BeatSaberModManager/Dependencies/AssemblyLocator.cs
+++ b/BeatSaberModManager/Dependencies/AssemblyLocator.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BeatSaberModManager.Dependencies
+{
+    // https://ayende.com/blog/1376/solving-the-assembly-load-context-problem
+    public static class AssemblyLocator
+    {
+        static Dictionary<string, Assembly> assemblies;
+        
+        public static void Init()
+        {
+            assemblies = new Dictionary<string, Assembly>();
+            AppDomain.CurrentDomain.AssemblyLoad += new AssemblyLoadEventHandler(CurrentDomain_AssemblyLoad);
+            AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(CurrentDomain_AssemblyResolve);
+        }
+        
+        static Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            Assembly assembly = null;
+            assemblies.TryGetValue(args.Name, out assembly);
+            return assembly;
+        }
+
+        static void CurrentDomain_AssemblyLoad(object sender, AssemblyLoadEventArgs args)
+        {
+            Assembly assembly = args.LoadedAssembly;
+            assemblies[assembly.FullName] = assembly;
+        }
+
+    }
+}

--- a/BeatSaberModManager/Forms/FormMain.Designer.cs
+++ b/BeatSaberModManager/Forms/FormMain.Designer.cs
@@ -62,6 +62,7 @@
             this.label2 = new System.Windows.Forms.Label();
             this.textBoxPluginsPath = new System.Windows.Forms.TextBox();
             this.helpInfoLabel3 = new System.Windows.Forms.Label();
+            this.columnHeaderInstalled = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.tabControlMain.SuspendLayout();
             this.tabPageCore.SuspendLayout();
             this.contextMenuStripMain.SuspendLayout();
@@ -158,7 +159,8 @@
             this.listViewMods.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.columnHeaderName,
             this.columnHeaderAuthor,
-            this.columnHeaderVersion});
+            this.columnHeaderVersion,
+            this.columnHeaderInstalled});
             this.listViewMods.ContextMenuStrip = this.contextMenuStripMain;
             this.listViewMods.FullRowSelect = true;
             this.listViewMods.Location = new System.Drawing.Point(6, 6);
@@ -178,12 +180,12 @@
             // columnHeaderAuthor
             // 
             this.columnHeaderAuthor.Text = "Author";
-            this.columnHeaderAuthor.Width = 150;
+            this.columnHeaderAuthor.Width = 130;
             // 
             // columnHeaderVersion
             // 
             this.columnHeaderVersion.Text = "Version";
-            this.columnHeaderVersion.Width = 107;
+            this.columnHeaderVersion.Width = 70;
             // 
             // contextMenuStripMain
             // 
@@ -431,6 +433,11 @@
             this.helpInfoLabel3.TabIndex = 3;
             this.helpInfoLabel3.Text = "You can uninstall mods by removing the .dll from that folder.";
             // 
+            // columnHeaderInstalled
+            // 
+            this.columnHeaderInstalled.Text = "Installed";
+            this.columnHeaderInstalled.Width = 70;
+            // 
             // FormMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -499,6 +506,7 @@
         private System.Windows.Forms.Label labelDiscordInfo;
         private System.Windows.Forms.LinkLabel linkLabelDiscord;
         private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.ColumnHeader columnHeaderInstalled;
     }
 }
 

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -20,6 +20,7 @@ namespace BeatSaberModManager
         UpdateLogic updater;
         RemoteLogic remote;
         InstallerLogic installer;
+        InstalledPluginsLogic installedPlugins;
         #endregion
 
         #region Constructor
@@ -29,6 +30,7 @@ namespace BeatSaberModManager
             path = new PathLogic();
             updater = new UpdateLogic();
             remote = new RemoteLogic();
+            installedPlugins = new InstalledPluginsLogic();
         }
         #endregion
 
@@ -39,8 +41,11 @@ namespace BeatSaberModManager
             {
                 textBoxDirectory.Text = path.GetInstallationPath();
                 updater.CheckForUpdates();
-
-                new Thread(() => { RemoteLoad(); }).Start();
+                new Thread(() => {
+                    UpdateStatus("Loading installed mods...");
+                    installedPlugins.LoadInstalledPlugins(path.installPath);
+                    RemoteLoad();
+                }).Start();
             }
             catch (Exception ex)
             {
@@ -76,6 +81,9 @@ namespace BeatSaberModManager
 
                 item.SubItems.Add(release.author);
                 item.SubItems.Add(release.version);
+
+                string installedVersion = installedPlugins.GetInstalledVersion(release.title);
+                item.SubItems.Add(installedVersion ?? "unknown");
 
                 if (release.platform == path.platform || release.platform == Platform.Default)
                 {


### PR DESCRIPTION
The currently installed version of a mod is now displayed in the plugin list.

This information is loaded directly from the plugin DLLs inside the `Plugin` directory.
The version number is sadly just a string, so there could be slight differences in the version naming scheme.

# Screenshot
![beatsabermodmanager_2018-10-28_13-37-13](https://user-images.githubusercontent.com/15067830/47615939-ac096500-dab6-11e8-8680-ec8a0d0fdebe.png)


# Version name differences 
![beatsabermodmanager_2018-10-28_13-37-37](https://user-images.githubusercontent.com/15067830/47615941-ae6bbf00-dab6-11e8-8d11-fc6be25330e4.png)

