### PR TITLE
fixed null issue when seeking install path

### DIFF
--- a/BeatSaberModManager/Core/PathLogic.cs
+++ b/BeatSaberModManager/Core/PathLogic.cs
@@ -119,12 +119,16 @@ namespace BeatSaberModManager.Core
                         using (RegistryKey libraryKey = librariesKey.OpenSubKey(libraryKeyName))
                         {
                             string libraryPath = (string) libraryKey.GetValue("Path");
-                            folderPath = Path.Combine(guidLetterVolumes.First(x => libraryPath.Contains(x.Key)).Value, libraryPath.Substring(49), subFolderPath);
-                            fullAppPath = Path.Combine(folderPath, AppFileName);
-
-                            if (File.Exists(fullAppPath))
+                            var libraryPathValue = guidLetterVolumes.FirstOrDefault(x => libraryPath.Contains(x.Key)).Value;
+                            if (libraryPathValue != null)
                             {
-                                return folderPath;
+                                folderPath = Path.Combine(libraryPathValue, libraryPath.Substring(49), subFolderPath);
+                                fullAppPath = Path.Combine(folderPath, AppFileName);
+
+                                if (File.Exists(fullAppPath))
+                                {
+                                    return folderPath;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
It seems that the following Linq query can result in no matches:

guidLetterVolumes.First(x => libraryPath.Contains(x.Key)).Value

My change accommodates this circumstance without a fatal error.  Please let me know if you need further information.